### PR TITLE
Proposed unit reworks modoption

### DIFF
--- a/gamedata/modrules.lua
+++ b/gamedata/modrules.lua
@@ -123,6 +123,10 @@ local modrules = {
 		healthScale = XPValues.healthScale,	-- Controls how gaining experience increases the maxDamage (total hitpoints) of the unit. The formula used is Health multiplier = healthScale * (1 + xp / (xp + 1)).
 		reloadScale = XPValues.reloadScale,	-- Controls how gaining experience decreases the reloadTime of the unit's weapons. The formula used is Rate of fire multiplier = reloadScale * (1 + xp / (xp + 1)).
 	},
+
+	damage = {
+		debris = 0, -- body parts flying off dead units
+	},
 }
 
 return modrules

--- a/luarules/gadgets/unit_footprint_clearance.lua
+++ b/luarules/gadgets/unit_footprint_clearance.lua
@@ -1,9 +1,9 @@
 function gadget:GetInfo()
     return {
-        name      = 'Engine Hotfixes for Various Engine Kludges',
-        desc      = '',
+        name      = 'Footprint clearance',
+        desc      = 'Clears ground under newly build units any features that are under its footprint',
         author    = '',
-        version   = 'v1.0',
+        version   = '',
         date      = 'April 2011',
         license   = 'GNU GPL, v2 or later',
         layer     = 0,
@@ -15,13 +15,9 @@ if not gadgetHandler:IsSyncedCode() then
 	return
 end
 
-local unitTurnrate = {}
 local unitXsize5 = {}
 local unitZsize5 = {}
 for unitDefID, unitDef in pairs(UnitDefs) do
-	if unitDef.moveDef and unitDef.moveDef.type ~= nil then
-		unitTurnrate[unitDefID] = unitDef.turnRate
-	end
 	if unitDef.isBuilding or unitDef.isFactory then
 		unitXsize5[unitDefID] = unitDef.xsize * 5
 		unitZsize5[unitDefID] = unitDef.zsize * 5
@@ -36,12 +32,6 @@ end
 
 function gadget:UnitCreated(uID, uDefID, uTeam, bID)
 
-	--Fix for bad movement in 102
-	--https://springrts.com/phpbb/viewtopic.php?f=12&t=34593
-	--if unitTurnrate[uDefID] then -- all non-flying units
-	--	Spring.MoveCtrl.SetGroundMoveTypeData(uID, "turnAccel", unitTurnrate[uDefID])
-	--end
-
 	--Instagibb any features that are unlucky enough to be in the build radius of new construction projects
 	if unitXsize5[uDefID] then	-- buildings/factories
 		local xr, zr
@@ -51,7 +41,7 @@ function gadget:UnitCreated(uID, uDefID, uTeam, bID)
 			xr, zr = unitZsize5[uDefID], unitXsize5[uDefID]
 		end
 
-		local ux, uy, uz = Spring.GetUnitPosition(uID)
+		local ux, _, uz = Spring.GetUnitPosition(uID)
 		local features = Spring.GetFeaturesInRectangle(ux-xr, uz-zr, ux+xr, uz+zr)
 		for i = 1, #features do
 			if gibFeatureDefs[Spring.GetFeatureDefID(features[i])] then
@@ -62,12 +52,4 @@ function gadget:UnitCreated(uID, uDefID, uTeam, bID)
 			end
 		end
 	end
-end
-
---Remove damage hardcoded in the engine of gibbed pieces of units (hardcoded to 50 damage in engine)
-function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
-	if weaponDefID == -1 then
-		return 0, 0
-	end
-	return damage, 1
 end


### PR DESCRIPTION
Changelist:
arm solar 2800 -> 2600 buildtime
arm wind 37->40m
cor wind 45->43m, 199->220hp
arm tidal 250->200e
arm asolar 370->350m

corcv 90 -> 95bp //cortex cons +5% bp, since they cost more
corck 80 -> 85
corca 60->65
cormuskrat 80 -> 85
coracv 250 -> 265
corack 180 -> 190
coraca 100 -> 105
corch 110 -> 115

corexp 2720 -> 2900 bt

Shuri 600 -> 700 dmg, 1.2 -> 1.4 reloadtime
Blitz 690 -> 725hp, LoS +50
Incisor buildtime +25%, energycost +10%, LoS +50
Grunt 36->45m, 880->750e, 270->300hp
Pawn 48->54m, 960->870e, 340->370hp
Tick 17->20m, 340->300e

Accurate lasers for everything
Rezzing energy cost 50% -> 100% of unit's original energy cost